### PR TITLE
test: unit tests for backend services + frontend automation features

### DIFF
--- a/expensive-tracker-backend/tests/unit/categoryService.test.js
+++ b/expensive-tracker-backend/tests/unit/categoryService.test.js
@@ -1,0 +1,93 @@
+jest.mock('../../src/models/Category');
+const Category = require('../../src/models/Category');
+const CategoryService = require('../../src/services/categoryService');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('CategoryService.getCategories', () => {
+  it('builds a filtered, sorted query', async () => {
+    const sort = jest.fn().mockResolvedValue([{ name: 'Food' }]);
+    Category.find.mockReturnValue({ sort });
+
+    const result = await CategoryService.getCategories('u1', { type: 'expense', isActive: true, sortOrder: 'desc' });
+
+    expect(Category.find).toHaveBeenCalledWith({ user: 'u1', type: 'expense', isActive: true });
+    expect(sort).toHaveBeenCalledWith({ name: -1 });
+    expect(result).toEqual([{ name: 'Food' }]);
+  });
+});
+
+describe('CategoryService.getCategory', () => {
+  it('returns the category when found', async () => {
+    Category.findOne.mockResolvedValue({ _id: 'c1', name: 'Food' });
+    await expect(CategoryService.getCategory('c1', 'u1')).resolves.toMatchObject({ name: 'Food' });
+  });
+
+  it('throws NotFoundError when missing', async () => {
+    Category.findOne.mockResolvedValue(null);
+    await expect(CategoryService.getCategory('c1', 'u1')).rejects.toThrow('Category not found');
+  });
+});
+
+describe('CategoryService.createCategory', () => {
+  it('throws ConflictError on duplicate name', async () => {
+    Category.findOne.mockResolvedValue({ _id: 'existing' });
+    await expect(CategoryService.createCategory({ name: 'Food' }, 'u1')).rejects.toThrow('already exists');
+    expect(Category.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the category when the name is free', async () => {
+    Category.findOne.mockResolvedValue(null);
+    Category.create.mockResolvedValue({ _id: 'c1', name: 'Food', user: 'u1' });
+
+    const result = await CategoryService.createCategory({ name: 'Food' }, 'u1');
+    expect(Category.create).toHaveBeenCalledWith({ name: 'Food', user: 'u1' });
+    expect(result.name).toBe('Food');
+  });
+});
+
+describe('CategoryService.updateCategory', () => {
+  it('rejects a rename that collides with another category', async () => {
+    Category.findOne.mockResolvedValue({ _id: 'other' });
+    await expect(CategoryService.updateCategory('c1', 'u1', { name: 'Food' })).rejects.toThrow('already exists');
+  });
+
+  it('throws NotFoundError when the category does not exist', async () => {
+    Category.findOne.mockResolvedValue(null); // no name clash
+    Category.findOneAndUpdate.mockResolvedValue(null);
+    await expect(CategoryService.updateCategory('c1', 'u1', { color: '#fff' })).rejects.toThrow('Category not found');
+  });
+
+  it('updates and returns the category', async () => {
+    Category.findOne.mockResolvedValue(null);
+    Category.findOneAndUpdate.mockResolvedValue({ _id: 'c1', color: '#fff' });
+    const result = await CategoryService.updateCategory('c1', 'u1', { color: '#fff' });
+    expect(result.color).toBe('#fff');
+  });
+});
+
+describe('CategoryService.deleteCategory', () => {
+  it('returns true when deleted', async () => {
+    Category.findOneAndDelete.mockResolvedValue({ _id: 'c1' });
+    await expect(CategoryService.deleteCategory('c1', 'u1')).resolves.toBe(true);
+  });
+
+  it('throws NotFoundError when nothing was deleted', async () => {
+    Category.findOneAndDelete.mockResolvedValue(null);
+    await expect(CategoryService.deleteCategory('c1', 'u1')).rejects.toThrow('Category not found');
+  });
+});
+
+describe('CategoryService.createDefaultCategories', () => {
+  it('bulk-inserts the default set, each tagged with the user', async () => {
+    Category.insertMany.mockImplementation((docs) => Promise.resolve(docs));
+    const result = await CategoryService.createDefaultCategories('u1');
+
+    expect(Category.insertMany).toHaveBeenCalledTimes(1);
+    const inserted = Category.insertMany.mock.calls[0][0];
+    expect(inserted.length).toBe(12);
+    expect(inserted.every((c) => c.user === 'u1')).toBe(true);
+    expect(inserted.some((c) => c.name === 'Salary' && c.type === 'income')).toBe(true);
+    expect(result.length).toBe(12);
+  });
+});

--- a/expensive-tracker-backend/tests/unit/currencyService.test.js
+++ b/expensive-tracker-backend/tests/unit/currencyService.test.js
@@ -1,0 +1,53 @@
+jest.mock('axios');
+const axios = require('axios');
+const currencyService = require('../../src/services/currencyService');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Reset the singleton's cache between tests.
+  currencyService.rates = null;
+  currencyService.lastFetched = null;
+});
+
+describe('CurrencyService.fetchRates', () => {
+  it('fetches and caches rates from the API', async () => {
+    axios.get.mockResolvedValue({ data: { rates: { USD: 1, LKR: 320 } } });
+
+    const rates = await currencyService.fetchRates();
+    expect(rates.LKR).toBe(320);
+    expect(axios.get).toHaveBeenCalledTimes(1);
+
+    // Second call within TTL should hit cache, not the API.
+    await currencyService.fetchRates();
+    expect(axios.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to default rates when the API fails', async () => {
+    axios.get.mockRejectedValue(new Error('network down'));
+
+    const rates = await currencyService.fetchRates();
+    expect(rates.USD).toBe(1);
+    expect(rates.LKR).toBe(300); // fallback value
+  });
+});
+
+describe('CurrencyService.convert', () => {
+  it('returns the same amount when currencies match', async () => {
+    const result = await currencyService.convert(100, 'USD', 'USD');
+    expect(result).toBe(100);
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  it('converts via USD using fetched rates', async () => {
+    axios.get.mockResolvedValue({ data: { rates: { USD: 1, LKR: 300, EUR: 0.5 } } });
+    // 300 LKR -> 1 USD -> 0.5 EUR
+    const result = await currencyService.convert(300, 'LKR', 'EUR');
+    expect(result).toBe(0.5);
+  });
+
+  it('returns the original amount when a rate is missing', async () => {
+    axios.get.mockResolvedValue({ data: { rates: { USD: 1 } } });
+    const result = await currencyService.convert(100, 'USD', 'XYZ');
+    expect(result).toBe(100);
+  });
+});

--- a/expensive-tracker-backend/tests/unit/expenseService.test.js
+++ b/expensive-tracker-backend/tests/unit/expenseService.test.js
@@ -1,0 +1,99 @@
+jest.mock('../../src/models/Expense');
+jest.mock('../../src/models/Category');
+jest.mock('../../src/models/Wallet');
+jest.mock('../../src/services/walletService');
+
+const Expense = require('../../src/models/Expense');
+const Category = require('../../src/models/Category');
+const Wallet = require('../../src/models/Wallet');
+const WalletService = require('../../src/services/walletService');
+const ExpenseService = require('../../src/services/expenseService');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  WalletService.updateBalance.mockResolvedValue({});
+});
+
+describe('ExpenseService.createExpense', () => {
+  it('throws NotFoundError when the category does not belong to the user', async () => {
+    Category.findOne.mockResolvedValue(null);
+    await expect(ExpenseService.createExpense({ category: 'c1', amount: 10 }, 'u1'))
+      .rejects.toThrow('Category not found');
+  });
+
+  it('throws NotFoundError when a supplied wallet is invalid', async () => {
+    Category.findOne.mockResolvedValue({ _id: 'c1', type: 'expense' });
+    Wallet.findOne.mockResolvedValue(null);
+    await expect(ExpenseService.createExpense({ category: 'c1', wallet: 'w1', amount: 10 }, 'u1'))
+      .rejects.toThrow('Wallet not found');
+  });
+
+  it('creates an expense and debits the wallet for an expense category', async () => {
+    Category.findOne.mockResolvedValue({ _id: 'c1', type: 'expense' });
+    Wallet.findOne.mockResolvedValue({ _id: 'w1' });
+    Expense.create.mockResolvedValue({ _id: 'e1', wallet: 'w1', amount: 100 });
+    // populate chain for the response
+    const populate2 = jest.fn().mockResolvedValue({ _id: 'e1', amount: 100 });
+    const populate1 = jest.fn().mockReturnValue({ populate: populate2 });
+    Expense.findById.mockReturnValue({ populate: populate1 });
+
+    await ExpenseService.createExpense({ category: 'c1', wallet: 'w1', amount: 100 }, 'u1');
+
+    // expense -> negative balance change
+    expect(WalletService.updateBalance).toHaveBeenCalledWith('w1', 'u1', -100);
+  });
+
+  it('credits the wallet for an income category', async () => {
+    Category.findOne.mockResolvedValue({ _id: 'c1', type: 'income' });
+    Wallet.findOne.mockResolvedValue({ _id: 'w1' });
+    Expense.create.mockResolvedValue({ _id: 'e1', wallet: 'w1', amount: 200 });
+    const populate2 = jest.fn().mockResolvedValue({ _id: 'e1' });
+    Expense.findById.mockReturnValue({ populate: jest.fn().mockReturnValue({ populate: populate2 }) });
+
+    await ExpenseService.createExpense({ category: 'c1', wallet: 'w1', amount: 200 }, 'u1');
+    expect(WalletService.updateBalance).toHaveBeenCalledWith('w1', 'u1', 200);
+  });
+});
+
+describe('ExpenseService.determineWallet', () => {
+  it('routes health/medical categories to the emergency fund', async () => {
+    Category.findById.mockResolvedValue({ name: 'Medical' });
+    Wallet.findOne.mockResolvedValue({ _id: 'emergency' });
+    const result = await ExpenseService.determineWallet('u1', 'c1');
+    expect(Wallet.findOne).toHaveBeenCalledWith({ user: 'u1', type: 'emergencyfund', isActive: true });
+    expect(result).toBe('emergency');
+  });
+
+  it('routes salary/rent to a bank wallet', async () => {
+    Category.findById.mockResolvedValue({ name: 'Rent' });
+    Wallet.findOne.mockResolvedValue({ _id: 'bank' });
+    const result = await ExpenseService.determineWallet('u1', 'c1');
+    expect(Wallet.findOne).toHaveBeenCalledWith({ user: 'u1', type: 'bank', isActive: true });
+    expect(result).toBe('bank');
+  });
+
+  it('throws BadRequestError when the user has no active wallet', async () => {
+    Category.findById.mockResolvedValue({ name: 'Misc' });
+    Wallet.findOne.mockResolvedValue(null); // no default and no any-wallet
+    await expect(ExpenseService.determineWallet('u1', 'c1')).rejects.toThrow('No active wallets');
+  });
+});
+
+describe('ExpenseService.deleteExpense', () => {
+  it('reverts the wallet balance and deletes', async () => {
+    Expense.findOne.mockReturnValue({
+      populate: jest.fn().mockResolvedValue({ _id: 'e1', wallet: 'w1', amount: 100, category: { type: 'expense' } })
+    });
+    Expense.deleteOne.mockResolvedValue({});
+
+    await ExpenseService.deleteExpense('e1', 'u1');
+    // deleting an expense refunds the wallet (+100)
+    expect(WalletService.updateBalance).toHaveBeenCalledWith('w1', 'u1', 100);
+    expect(Expense.deleteOne).toHaveBeenCalledWith({ _id: 'e1' });
+  });
+
+  it('throws NotFoundError when the expense is missing', async () => {
+    Expense.findOne.mockReturnValue({ populate: jest.fn().mockResolvedValue(null) });
+    await expect(ExpenseService.deleteExpense('e1', 'u1')).rejects.toThrow('Expense not found');
+  });
+});

--- a/expensive-tracker-backend/tests/unit/productBudgetService.test.js
+++ b/expensive-tracker-backend/tests/unit/productBudgetService.test.js
@@ -1,0 +1,80 @@
+jest.mock('../../src/models/ProductBudget');
+const ProductBudget = require('../../src/models/ProductBudget');
+const ProductBudgetService = require('../../src/services/productBudgetService');
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('ProductBudgetService.createProductBudget', () => {
+  it('stamps the user and creates the budget', async () => {
+    ProductBudget.create.mockImplementation((data) => Promise.resolve({ _id: 'b1', ...data }));
+    const result = await ProductBudgetService.createProductBudget({ name: 'Laptop', targetAmount: 1000 }, 'u1');
+    expect(ProductBudget.create).toHaveBeenCalledWith({ name: 'Laptop', targetAmount: 1000, user: 'u1' });
+    expect(result.user).toBe('u1');
+  });
+});
+
+describe('ProductBudgetService.getProductBudgets', () => {
+  it('filters by user and active flag, newest first', async () => {
+    const sort = jest.fn().mockResolvedValue([{ name: 'Laptop' }]);
+    ProductBudget.find.mockReturnValue({ sort });
+
+    await ProductBudgetService.getProductBudgets('u1', { isActive: 'true' });
+    expect(ProductBudget.find).toHaveBeenCalledWith({ user: 'u1', isActive: true });
+    expect(sort).toHaveBeenCalledWith({ createdAt: -1 });
+  });
+});
+
+describe('ProductBudgetService.getProductBudgetById', () => {
+  it('throws NotFoundError when missing', async () => {
+    ProductBudget.findOne.mockResolvedValue(null);
+    await expect(ProductBudgetService.getProductBudgetById('b1', 'u1')).rejects.toThrow('not found');
+  });
+});
+
+describe('ProductBudgetService.updateProductBudget / updateSavedAmount', () => {
+  it('updates and returns the budget', async () => {
+    ProductBudget.findOneAndUpdate.mockResolvedValue({ _id: 'b1', name: 'Phone' });
+    const result = await ProductBudgetService.updateProductBudget('b1', 'u1', { name: 'Phone' });
+    expect(result.name).toBe('Phone');
+  });
+
+  it('updateSavedAmount throws NotFoundError when missing', async () => {
+    ProductBudget.findOneAndUpdate.mockResolvedValue(null);
+    await expect(ProductBudgetService.updateSavedAmount('b1', 'u1', 500)).rejects.toThrow('not found');
+  });
+});
+
+describe('ProductBudgetService.deleteProductBudget', () => {
+  it('returns true when deleted, throws when not', async () => {
+    ProductBudget.findOneAndDelete.mockResolvedValueOnce({ _id: 'b1' });
+    await expect(ProductBudgetService.deleteProductBudget('b1', 'u1')).resolves.toBe(true);
+
+    ProductBudget.findOneAndDelete.mockResolvedValueOnce(null);
+    await expect(ProductBudgetService.deleteProductBudget('b1', 'u1')).rejects.toThrow('not found');
+  });
+});
+
+describe('ProductBudgetService.getProductBudgetsSummary', () => {
+  it('aggregates totals and average progress across active budgets', async () => {
+    ProductBudget.find.mockResolvedValue([
+      { targetAmount: 1000, savedAmount: 500, progress: 50 },
+      { targetAmount: 2000, savedAmount: 500, progress: 25 }
+    ]);
+
+    const summary = await ProductBudgetService.getProductBudgetsSummary('u1');
+    expect(summary).toEqual({
+      totalBudgets: 2,
+      totalTargetAmount: 3000,
+      totalSavedAmount: 1000,
+      totalRemainingAmount: 2000,
+      averageProgress: 38 // round((50+25)/2)
+    });
+  });
+
+  it('handles the no-budgets case without dividing by zero', async () => {
+    ProductBudget.find.mockResolvedValue([]);
+    const summary = await ProductBudgetService.getProductBudgetsSummary('u1');
+    expect(summary.totalBudgets).toBe(0);
+    expect(summary.averageProgress).toBe(0);
+  });
+});

--- a/expensive-tracker-backend/tests/unit/receiptOcrService.test.js
+++ b/expensive-tracker-backend/tests/unit/receiptOcrService.test.js
@@ -1,0 +1,63 @@
+jest.mock('axios');
+jest.mock('fs');
+jest.mock('../../src/utils/logger', () => ({ warn: jest.fn(), error: jest.fn(), info: jest.fn() }));
+
+const axios = require('axios');
+const fs = require('fs');
+
+// The service reads OCR_API_KEY in its constructor, so we re-require it per test
+// with the desired env using jest.isolateModules.
+const loadService = () => {
+  let svc;
+  jest.isolateModules(() => { svc = require('../../src/services/receiptOcrService'); });
+  return svc;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  fs.readFileSync.mockReturnValue(Buffer.from('img-bytes'));
+});
+
+describe('ReceiptOcrService.extractText', () => {
+  it('reports not-configured and skips the network when no key is set', async () => {
+    delete process.env.OCR_API_KEY;
+    const service = loadService();
+
+    const result = await service.extractText('/tmp/receipt.jpg');
+    expect(result).toEqual({ configured: false, rawText: '' });
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  it('posts the image and returns parsed text when configured', async () => {
+    process.env.OCR_API_KEY = 'key-123';
+    const service = loadService();
+    axios.post.mockResolvedValue({
+      data: { IsErroredOnProcessing: false, ParsedResults: [{ ParsedText: 'KEELLS\nTOTAL 1200.00' }] }
+    });
+
+    const result = await service.extractText('/tmp/receipt.jpg');
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(result.configured).toBe(true);
+    expect(result.rawText).toContain('KEELLS');
+  });
+
+  it('degrades to empty text when the provider errors', async () => {
+    process.env.OCR_API_KEY = 'key-123';
+    const service = loadService();
+    axios.post.mockRejectedValue(new Error('provider down'));
+
+    const result = await service.extractText('/tmp/receipt.jpg');
+    expect(result).toEqual({ configured: true, rawText: '' });
+  });
+
+  it('returns empty text when the provider reports a processing error', async () => {
+    process.env.OCR_API_KEY = 'key-123';
+    const service = loadService();
+    axios.post.mockResolvedValue({ data: { IsErroredOnProcessing: true, ErrorMessage: ['bad image'] } });
+
+    const result = await service.extractText('/tmp/receipt.jpg');
+    expect(result.rawText).toBe('');
+  });
+
+  afterEach(() => { delete process.env.OCR_API_KEY; });
+});

--- a/expensive-tracker-backend/tests/unit/recurringScheduler.test.js
+++ b/expensive-tracker-backend/tests/unit/recurringScheduler.test.js
@@ -1,0 +1,43 @@
+jest.mock('../../src/services/recurringService');
+jest.mock('../../src/utils/logger', () => ({ info: jest.fn(), error: jest.fn() }));
+
+const RecurringService = require('../../src/services/recurringService');
+const { startRecurringScheduler } = require('../../src/services/recurringScheduler');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+  RecurringService.processDueRecurringExpenses.mockResolvedValue({ occurrencesCreated: 0 });
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('startRecurringScheduler', () => {
+  it('runs immediately on start and then on each interval', async () => {
+    const timer = startRecurringScheduler({ intervalMs: 1000 });
+
+    // Immediate boot run.
+    expect(RecurringService.processDueRecurringExpenses).toHaveBeenCalledTimes(1);
+
+    // Two more interval ticks.
+    jest.advanceTimersByTime(2000);
+    expect(RecurringService.processDueRecurringExpenses).toHaveBeenCalledTimes(3);
+
+    clearInterval(timer);
+  });
+
+  it('returns a timer that has been unref-ed (does not keep the loop alive)', () => {
+    const timer = startRecurringScheduler({ intervalMs: 1000 });
+    // Node timers expose unref; jest fake timers return an object with it.
+    expect(typeof timer).toBeDefined();
+    clearInterval(timer);
+  });
+
+  it('swallows a run failure without throwing', () => {
+    RecurringService.processDueRecurringExpenses.mockRejectedValue(new Error('boom'));
+    expect(() => startRecurringScheduler({ intervalMs: 1000 })).not.toThrow();
+  });
+});

--- a/expensive-tracker-backend/tests/unit/userService.test.js
+++ b/expensive-tracker-backend/tests/unit/userService.test.js
@@ -1,0 +1,95 @@
+jest.mock('../../src/models/User');
+jest.mock('jsonwebtoken');
+
+const User = require('../../src/models/User');
+const jwt = require('jsonwebtoken');
+const UserService = require('../../src/services/userService');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.JWT_SECRET = 'test-secret';
+  jwt.sign.mockReturnValue('signed.jwt.token');
+});
+
+describe('UserService.generateToken', () => {
+  it('signs the user id with the configured secret', () => {
+    const token = UserService.generateToken('u1');
+    expect(jwt.sign).toHaveBeenCalledWith({ id: 'u1' }, 'test-secret', expect.objectContaining({ expiresIn: expect.any(String) }));
+    expect(token).toBe('signed.jwt.token');
+  });
+});
+
+describe('UserService.register', () => {
+  it('throws ConflictError when the email is already taken', async () => {
+    User.findOne.mockResolvedValue({ _id: 'existing' });
+    await expect(UserService.register({ email: 'a@b.com', password: 'x', name: 'A' }))
+      .rejects.toThrow('already exists');
+    expect(User.create).not.toHaveBeenCalled();
+  });
+
+  it('creates the user, defaults currency to LKR, and returns a token', async () => {
+    User.findOne.mockResolvedValue(null);
+    const save = jest.fn().mockResolvedValue({});
+    User.create.mockResolvedValue({ _id: 'u1', name: 'A', email: 'a@b.com', currency: 'LKR', save });
+
+    const result = await UserService.register({ email: 'a@b.com', password: 'x', name: 'A' });
+
+    expect(User.create).toHaveBeenCalledWith(expect.objectContaining({ currency: 'LKR' }));
+    expect(result.token).toBe('signed.jwt.token');
+    expect(result.user).toMatchObject({ id: 'u1', email: 'a@b.com' });
+  });
+});
+
+describe('UserService.login', () => {
+  const buildUser = (overrides = {}) => {
+    const user = {
+      _id: 'u1', name: 'A', email: 'a@b.com', currency: 'LKR', isActive: true, role: 'user',
+      comparePassword: jest.fn().mockResolvedValue(true),
+      save: jest.fn().mockResolvedValue({}),
+      ...overrides
+    };
+    return user;
+  };
+
+  const mockFindOneWithPassword = (user) => {
+    User.findOne.mockReturnValue({ select: jest.fn().mockResolvedValue(user) });
+  };
+
+  it('throws on unknown email', async () => {
+    mockFindOneWithPassword(null);
+    await expect(UserService.login('none@b.com', 'x')).rejects.toThrow('Invalid credentials');
+  });
+
+  it('throws when the account is deactivated', async () => {
+    mockFindOneWithPassword(buildUser({ isActive: false }));
+    await expect(UserService.login('a@b.com', 'x')).rejects.toThrow('deactivated');
+  });
+
+  it('throws on wrong password', async () => {
+    mockFindOneWithPassword(buildUser({ comparePassword: jest.fn().mockResolvedValue(false) }));
+    await expect(UserService.login('a@b.com', 'bad')).rejects.toThrow('Invalid credentials');
+  });
+
+  it('returns user + token on success', async () => {
+    const user = buildUser();
+    mockFindOneWithPassword(user);
+    const result = await UserService.login('a@b.com', 'right');
+    expect(user.save).toHaveBeenCalled(); // updates lastLogin
+    expect(result.token).toBe('signed.jwt.token');
+    expect(result.user.id).toBe('u1');
+  });
+});
+
+describe('UserService.getProfile / verifyToken', () => {
+  it('getProfile throws NotFoundError when the user is gone', async () => {
+    User.findById.mockResolvedValue(null);
+    await expect(UserService.getProfile('u1')).rejects.toThrow('User not found');
+  });
+
+  it('verifyToken returns public user data with valid:true', async () => {
+    User.findById.mockResolvedValue({ _id: 'u1', name: 'A', email: 'a@b.com', isActive: true, role: 'user' });
+    const result = await UserService.verifyToken('u1');
+    expect(result.valid).toBe(true);
+    expect(result.user.id).toBe('u1');
+  });
+});

--- a/expensive-tracker-backend/tests/unit/utils.test.js
+++ b/expensive-tracker-backend/tests/unit/utils.test.js
@@ -1,0 +1,72 @@
+const errors = require('../../src/utils/errors');
+const { successResponse, createdResponse, errorResponse, paginatedResponse, noContentResponse } = require('../../src/utils/responseFormatter');
+
+// Minimal Express response double.
+const mockRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  res.send = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('error classes', () => {
+  it('carry the correct status codes and default messages', () => {
+    expect(new errors.NotFoundError().statusCode).toBe(404);
+    expect(new errors.ValidationError().statusCode).toBe(400);
+    expect(new errors.UnauthorizedError().statusCode).toBe(401);
+    expect(new errors.ForbiddenError().statusCode).toBe(403);
+    expect(new errors.BadRequestError().statusCode).toBe(400);
+    expect(new errors.ConflictError().statusCode).toBe(409);
+  });
+
+  it('are operational and preserve custom messages', () => {
+    const err = new errors.NotFoundError('Widget not found');
+    expect(err.isOperational).toBe(true);
+    expect(err.message).toBe('Widget not found');
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe('responseFormatter', () => {
+  it('successResponse sends success:true with data and optional message', () => {
+    const res = mockRes();
+    successResponse(res, { a: 1 }, 200, 'ok');
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ success: true, message: 'ok', data: { a: 1 } });
+  });
+
+  it('successResponse omits data when null', () => {
+    const res = mockRes();
+    successResponse(res, null);
+    expect(res.json).toHaveBeenCalledWith({ success: true });
+  });
+
+  it('createdResponse uses 201', () => {
+    const res = mockRes();
+    createdResponse(res, { id: 1 });
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('errorResponse sends success:false with error and details', () => {
+    const res = mockRes();
+    errorResponse(res, 'nope', 422, { field: 'x' });
+    expect(res.status).toHaveBeenCalledWith(422);
+    expect(res.json).toHaveBeenCalledWith({ success: false, error: 'nope', details: { field: 'x' } });
+  });
+
+  it('paginatedResponse computes pagination metadata', () => {
+    const res = mockRes();
+    paginatedResponse(res, [1, 2], 1, 2, 5);
+    const body = res.json.mock.calls[0][0];
+    expect(body.total).toBe(5);
+    expect(body.pagination).toMatchObject({ page: 1, pages: 3, hasNext: true, hasPrev: false });
+  });
+
+  it('noContentResponse sends 204', () => {
+    const res = mockRes();
+    noContentResponse(res);
+    expect(res.status).toHaveBeenCalledWith(204);
+    expect(res.send).toHaveBeenCalled();
+  });
+});

--- a/expensive-tracker-frontend/src/app/Navigation/components/import-scan/import-scan.component.spec.ts
+++ b/expensive-tracker-frontend/src/app/Navigation/components/import-scan/import-scan.component.spec.ts
@@ -1,0 +1,139 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+
+import { ImportScanComponent } from './import-scan.component';
+import { ImportService } from '../../../services/import.service';
+import { TransactionService } from '../../../services/transaction.service';
+import { WalletService } from '../../../services/wallet.service';
+
+describe('ImportScanComponent', () => {
+  let component: ImportScanComponent;
+  let fixture: ComponentFixture<ImportScanComponent>;
+  let importService: jasmine.SpyObj<ImportService>;
+  let transactionService: jasmine.SpyObj<TransactionService>;
+
+  const wallets = [{ id: 'w1', name: 'Bank', type: 'bank', isActive: true }];
+  const categories = [{ _id: 'c1', name: 'Food', type: 'expense' }];
+
+  beforeEach(async () => {
+    importService = jasmine.createSpyObj('ImportService', ['scanReceipt', 'importBankText', 'importBankFile', 'importSms']);
+    transactionService = jasmine.createSpyObj('TransactionService', ['getCategories', 'addTransaction', 'refreshTransactions']);
+    const walletService = { wallets$: of(wallets) };
+
+    transactionService.getCategories.and.returnValue(of(categories) as any);
+
+    await TestBed.configureTestingModule({
+      imports: [ImportScanComponent],
+      providers: [
+        { provide: ImportService, useValue: importService },
+        { provide: TransactionService, useValue: transactionService },
+        { provide: WalletService, useValue: walletService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImportScanComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges(); // triggers ngOnInit
+  });
+
+  it('creates and loads wallets + categories, defaulting the wallet', () => {
+    expect(component).toBeTruthy();
+    expect(component.wallets.length).toBe(1);
+    expect(component.categories.length).toBe(1);
+    expect(component.selectedWalletId).toBe('w1');
+  });
+
+  it('switches main tabs', () => {
+    expect(component.activeTab).toBe('receipt');
+    component.setTab('import');
+    expect(component.activeTab).toBe('import');
+  });
+
+  describe('receipt scan', () => {
+    const scanResult = {
+      receipt: 'http://x/uploads/r.jpg',
+      ocrConfigured: true,
+      suggestion: { title: 'KEELLS', amount: 1200, date: '2026-01-12T00:00:00.000Z', merchant: 'KEELLS', category: 'c1', categoryName: 'Food' },
+      rawText: 'KEELLS'
+    };
+
+    it('stores the scan result on success', () => {
+      importService.scanReceipt.and.returnValue(of(scanResult));
+      component.receiptFile = new File(['x'], 'r.jpg');
+
+      component.scanReceipt();
+
+      expect(component.scanResult).toEqual(scanResult);
+      expect(component.scanning).toBeFalse();
+    });
+
+    it('surfaces an error message on failure', () => {
+      importService.scanReceipt.and.returnValue(throwError(() => new Error('scan failed')));
+      component.receiptFile = new File(['x'], 'r.jpg');
+
+      component.scanReceipt();
+
+      expect(component.receiptError).toBe('scan failed');
+      expect(component.scanResult).toBeNull();
+    });
+
+    it('validates before creating an expense', () => {
+      component.scanResult = { ...scanResult, suggestion: { ...scanResult.suggestion, amount: null } };
+      component.createFromReceipt();
+      expect(component.receiptError).toContain('amount');
+      expect(transactionService.addTransaction).not.toHaveBeenCalled();
+    });
+
+    it('creates an expense from a valid suggestion', () => {
+      transactionService.addTransaction.and.returnValue(of({}) as any);
+      component.scanResult = scanResult as any;
+      component.selectedWalletId = 'w1';
+
+      component.createFromReceipt();
+
+      expect(transactionService.addTransaction).toHaveBeenCalled();
+      expect(component.expenseCreated).toBeTrue();
+    });
+  });
+
+  describe('import', () => {
+    const summary = { total: 2, created: 0, duplicates: 0, unmatched: 0, dryRun: true, results: [] };
+
+    it('requires a wallet before running', () => {
+      component.selectedWalletId = '';
+      component.runImport(true);
+      expect(component.importError).toContain('wallet');
+    });
+
+    it('runs a CSV-text preview and stores the summary', () => {
+      importService.importBankText.and.returnValue(of(summary));
+      component.setImportMode('text');
+      component.csvText = 'Date,Description,Amount\n12/01/2026,UBER,-100';
+      component.selectedWalletId = 'w1';
+
+      component.runImport(true);
+
+      expect(importService.importBankText).toHaveBeenCalled();
+      expect(component.summary).toEqual(summary);
+      expect(component.lastRunWasPreview).toBeTrue();
+    });
+
+    it('refreshes transactions after a committing import that created rows', () => {
+      importService.importSms.and.returnValue(of({ ...summary, dryRun: false, created: 1 }));
+      component.setImportMode('sms');
+      component.smsText = 'debited LKR 100 at CAFE';
+      component.selectedWalletId = 'w1';
+
+      component.runImport(false);
+
+      expect(transactionService.refreshTransactions).toHaveBeenCalled();
+    });
+  });
+
+  it('maps statuses to colour classes', () => {
+    expect(component.statusClass('created')).toContain('green');
+    expect(component.statusClass('duplicate')).toContain('amber');
+    expect(component.statusClass('unmatched')).toContain('gray');
+    expect(component.statusClass('error')).toContain('red');
+  });
+});

--- a/expensive-tracker-frontend/src/app/services/import.service.spec.ts
+++ b/expensive-tracker-frontend/src/app/services/import.service.spec.ts
@@ -1,0 +1,84 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ImportService, ImportSummary, ReceiptScanResult } from './import.service';
+import { environment } from '../../environments/environment';
+
+describe('ImportService', () => {
+  let service: ImportService;
+  let httpMock: HttpTestingController;
+  const api = environment.apiUrl;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [ImportService]
+    });
+    service = TestBed.inject(ImportService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('is created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('scanReceipt posts multipart form data and unwraps data', () => {
+    const mock: ReceiptScanResult = {
+      receipt: 'http://x/uploads/r.jpg',
+      ocrConfigured: true,
+      suggestion: { title: 'KEELLS', amount: 1200, date: '2026-01-12T00:00:00.000Z', merchant: 'KEELLS', category: 'c1', categoryName: 'Food' },
+      rawText: 'KEELLS\nTOTAL 1200'
+    };
+
+    let result: ReceiptScanResult | undefined;
+    service.scanReceipt(new File(['x'], 'r.jpg')).subscribe((r) => (result = r));
+
+    const req = httpMock.expectOne(`${api}/expenses/receipt/scan`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body instanceof FormData).toBeTrue();
+    req.flush({ success: true, data: mock });
+
+    expect(result).toEqual(mock);
+  });
+
+  it('importBankText posts JSON with csv + options', () => {
+    const summary: ImportSummary = { total: 1, created: 1, duplicates: 0, unmatched: 0, dryRun: false, results: [] };
+    service.importBankText('Date,Description,Amount', { walletId: 'w1', dryRun: false }).subscribe();
+
+    const req = httpMock.expectOne(`${api}/imports/bank`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ csv: 'Date,Description,Amount', walletId: 'w1', dryRun: false });
+    req.flush({ success: true, data: summary });
+  });
+
+  it('importBankFile posts multipart with the file and options', () => {
+    service.importBankFile(new File(['a,b'], 's.csv'), { walletId: 'w1', dryRun: true }).subscribe();
+
+    const req = httpMock.expectOne(`${api}/imports/bank`);
+    const body = req.request.body as FormData;
+    expect(body instanceof FormData).toBeTrue();
+    expect(body.get('walletId')).toBe('w1');
+    expect(body.get('dryRun')).toBe('true');
+    expect(body.get('file')).toBeTruthy();
+    req.flush({ success: true, data: { total: 0, created: 0, duplicates: 0, unmatched: 0, dryRun: true, results: [] } });
+  });
+
+  it('importSms posts the messages array', () => {
+    service.importSms(['msg one', 'msg two'], { walletId: 'w1' }).subscribe();
+
+    const req = httpMock.expectOne(`${api}/imports/sms`);
+    expect(req.request.body).toEqual({ messages: ['msg one', 'msg two'], walletId: 'w1' });
+    req.flush({ success: true, data: { total: 2, created: 2, duplicates: 0, unmatched: 0, dryRun: false, results: [] } });
+  });
+
+  it('maps backend errors to a readable message', () => {
+    let error: Error | undefined;
+    service.importSms(['x']).subscribe({ error: (e) => (error = e) });
+
+    const req = httpMock.expectOne(`${api}/imports/sms`);
+    req.flush({ success: false, error: 'No recognizable transaction alerts found' }, { status: 400, statusText: 'Bad Request' });
+
+    expect(error?.message).toBe('No recognizable transaction alerts found');
+  });
+});


### PR DESCRIPTION
Stacked on #42 (base: `feature/expense-automation`) so this diff is **tests only**.

## Backend — 8 new suites (mocked models, no DB required)
| Suite | Covers |
|---|---|
| `currencyService` | rate caching, API fallback, conversion, missing-rate |
| `expenseService` | create (category/wallet validation, balance debit vs credit), `determineWallet` routing, delete-with-revert |
| `categoryService` | CRUD, duplicate conflicts, default-category bulk insert |
| `productBudgetService` | CRUD, saved-amount, summary aggregation (+ zero-division) |
| `userService` | token gen, register/login (all branches), profile/verify |
| `receiptOcrService` | no-key degradation, provider success/error paths |
| `recurringScheduler` | boot + interval runs, failure isolation |
| `utils` | error classes (status codes) + `responseFormatter` |

## Frontend — 2 new specs
- `import.service.spec.ts` — receipt scan (multipart), bank text/file, SMS, error mapping
- `import-scan.component.spec.ts` — tab switching, receipt scan + create, import preview/commit, validation, status classes

## Verification
- **Backend:** full suite **125 tests / 17 suites pass** (was 68).
- **Frontend:** the 2 new specs run headless in Chrome — **16/16 pass**.
- No source files changed — tests only.

## Notes
- The rest of the frontend already had Angular-scaffolded `.spec.ts` files; new specs target the automation code that had none.
- Thin controllers are covered indirectly via service tests + earlier supertest/E2E checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)